### PR TITLE
Add a description struct tag to generated go structs

### DIFF
--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -213,7 +213,7 @@ func TestBuildStructs(t *testing.T) {
 			}
 
 			if string(got) != string(want) {
-				t.Errorf("Test %q - file %q got %q != want %q", test.description, test.expectedFiles[i], got, want)
+				t.Errorf("Test %q - file %q got\n%s\n!= want\n%s", test.description, test.expectedFiles[i], got, want)
 			}
 
 			if err := os.Remove(filepath.Join(testdir, test.expectedFiles[i])); err != nil {

--- a/generate/test_data/complex.go.out
+++ b/generate/test_data/complex.go.out
@@ -10,8 +10,8 @@ type Complex struct {
 	Crops   []struct {
 		Height       float64 `json:"height"`
 		Name         string  `json:"name"`
-		Path         string  `json:"path"`
-		RelativePath string  `json:"relativePath"`
+		Path         string  `json:"path" description:"full path to the cropped image file"`
+		RelativePath string  `json:"relativePath" description:"a long"`
 		Width        float64 `json:"width"`
 	} `json:"crops"`
 	Cutline        string `json:"cutline,omitempty"`
@@ -21,7 +21,7 @@ type Complex struct {
 		Height float64 `json:"height"`
 		Width  float64 `json:"width"`
 	} `json:"originalSize"`
-	Type string `json:"type"`
+	Type string `json:"type" description:"a type"`
 	URL  struct {
 		Absolute string `json:"absolute"`
 		Publish  string `json:"publish"`

--- a/generate/test_data/complex.go.out2
+++ b/generate/test_data/complex.go.out2
@@ -8,8 +8,8 @@ type Complex struct {
 	Crops   []struct {
 		Height       float64 `json:"height"`
 		Name         string  `json:"name"`
-		Path         string  `json:"path"`
-		RelativePath string  `json:"relativePath"`
+		Path         string  `json:"path" description:"full path to the cropped image file"`
+		RelativePath string  `json:"relativePath" description:"a long"`
 		Width        float64 `json:"width"`
 	} `json:"crops"`
 	Cutline        string `json:"cutline,omitempty"`
@@ -19,7 +19,7 @@ type Complex struct {
 		Height float64 `json:"height"`
 		Width  float64 `json:"width"`
 	} `json:"originalSize"`
-	Type string `json:"type"`
+	Type string `json:"type" description:"a type"`
 	URL  struct {
 		Absolute string `json:"absolute"`
 		Publish  string `json:"publish"`

--- a/generate/test_data/complex.json
+++ b/generate/test_data/complex.json
@@ -3,6 +3,7 @@
     "type": "object",
     "properties": {
         "type": {
+            "description": "a type",
             "type": "string",
             "enum": [
                 "image"
@@ -80,6 +81,7 @@
                         }
                     },
                     "path": {
+                        "description": "full path to the cropped image file",
                         "type": "string",
                         "transform": {
                             "cumulo": {
@@ -99,6 +101,7 @@
                         }
                     },
                     "relativePath": {
+                        "description": "a long\nmulti-line description",
                         "type": "string",
                         "transform": {
                             "cumulo": {

--- a/generate/test_data/test_data_msgp.go.out
+++ b/generate/test_data/test_data_msgp.go.out
@@ -46,8 +46,8 @@ func (z *Complex) DecodeMsg(dc *msgp.Reader) (err error) {
 				z.Crops = make([]struct {
 					Height       float64 `json:"height"`
 					Name         string  `json:"name"`
-					Path         string  `json:"path"`
-					RelativePath string  `json:"relativePath"`
+					Path         string  `json:"path" description:"full path to the cropped image file"`
+					RelativePath string  `json:"relativePath" description:"a long"`
 					Width        float64 `json:"width"`
 				}, zb0002)
 			}
@@ -444,8 +444,8 @@ func (z *Complex) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				z.Crops = make([]struct {
 					Height       float64 `json:"height"`
 					Name         string  `json:"name"`
-					Path         string  `json:"path"`
-					RelativePath string  `json:"relativePath"`
+					Path         string  `json:"path" description:"full path to the cropped image file"`
+					RelativePath string  `json:"relativePath" description:"a long"`
 					Width        float64 `json:"width"`
 				}, zb0002)
 			}


### PR DESCRIPTION
The description is pulled from the corresponding JSON schema description
for the field. Adding it as a struct tag allows using it as metadata
in the go code.