### PR TITLE
Add a function to better handle writing deleted data as Avro files

### DIFF
--- a/generate/avro_helpers.go
+++ b/generate/avro_helpers.go
@@ -20,6 +20,13 @@ type AvroCFWriter interface {
 	WriteAvroCF(io.Writer, time.Time) error
 }
 
+// AvroCFDeleter implements functionality to write an Avro Container file with the metadata field AvroDeleted set
+// to true. This is a record that a delete of the given item occurred but is writing a new Container File. This enables
+// adhering to the the Avro Schema for the given data type and tracking history of changes for any given ID.
+type AvroCFDeleter interface {
+	WriteAvroDeletedCF(io.Writer, time.Time) error
+}
+
 // AvroTime converts the given time.Time into an int64 compatible with an Avro timestamp.millis logical type.
 // http://avro.apache.org/docs/current/spec.html#Date
 func AvroTime(t time.Time) int64 {

--- a/generate/test_data/arrays_avro.go
+++ b/generate/test_data/arrays_avro.go
@@ -1,6 +1,7 @@
 package test_data
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -12,10 +13,12 @@ import (
 
 // WriteAvroCF writes an Avro Containter File to the given io.Writer using snappy compression for the data.
 // The time is used as the AvroWriteTime, if the time is the Zero value then the current time is used.
-// If z is nil then the data will be a delete as indicated by the AvroDeleted field.
 // NOTE: If the type has a field in an embedded struct with the same name as a field not in the embedded struct the
 // value will be pulled from the field not in the embedded struct.
 func (z *Arrays) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
 	if writeTime.IsZero() {
 		writeTime = time.Now()
 	}
@@ -25,6 +28,28 @@ func (z *Arrays) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
 	}
 
 	if err := avroWriter.WriteRecord(z.convertToAvro(writeTime)); err != nil {
+		return err
+	}
+
+	return avroWriter.Flush()
+}
+
+// WriteAvroDeletedCF works nearly identically to WriteAvroCF but sets the AvroDeleted metadata field to true.
+func (z *Arrays) WriteAvroDeletedCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
+	if writeTime.IsZero() {
+		writeTime = time.Now()
+	}
+	avroWriter, err := arrays.NewArraysWriter(writer, container.Snappy, 1)
+	if err != nil {
+		return err
+	}
+
+	converted := z.convertToAvro(writeTime)
+	converted.AvroDeleted = true
+	if err := avroWriter.WriteRecord(converted); err != nil {
 		return err
 	}
 
@@ -63,6 +88,8 @@ func (z *Arrays) convertToAvro(writeTime time.Time) *arrays.Arrays {
 // The given writeTime will be used for all data items written by this function.
 // When the returned request channel is closed this function will finalize the Container File and exit.
 // The returned error channel will be closed just before the go routine exits.
+// Note: That though a nil item will be written as delete it will also be written without an ID or other identifying
+// field and so this is of limited value. In general deletes should be done using WriteAvroDeletedCF.
 func ArraysBulkAvroWriter(writer io.Writer, writeTime time.Time, request <-chan *Arrays) <-chan error {
 	if writeTime.IsZero() {
 		writeTime = time.Now()

--- a/generate/test_data/arrays_avro_test.go
+++ b/generate/test_data/arrays_avro_test.go
@@ -44,6 +44,39 @@ func TestArrays_WriteAvroCF(t *testing.T) {
 	}
 }
 
+func TestArrays_WriteAvroDeletedCF(t *testing.T) {
+	z := &Arrays{} // In real usage at minimum an ID field should be populated
+
+	// compile error if for some reason z does not implement generate.AvroCFDeleter
+	var _ generate.AvroCFDeleter = z
+
+	// write to a CF file
+	now := time.Now()
+	buf := &bytes.Buffer{}
+	err := z.WriteAvroDeletedCF(buf, now)
+	if err != nil {
+		t.Fatalf("Unexpected error writing to a CF file: %v", err)
+	}
+
+	ocfReader, err := arrays.NewArraysReader(buf)
+	if err != nil {
+		t.Fatalf("Error creating OCF file reader: %v\n", err)
+	}
+
+	read, err := ocfReader.Read()
+	if err != nil {
+		t.Fatalf("Failed reading from OCF file reader: %v\n", err)
+	}
+
+	if got, want := read.AvroWriteTime, generate.AvroTime(now); got != want {
+		t.Errorf("Time is wrong, got %d, want %d", got, want)
+	}
+
+	if read.AvroDeleted != true {
+		t.Error("OCF reports deleted false expected true")
+	}
+}
+
 func ExampleArraysBulkAvroWrite() {
 	input := []*Arrays{{}, {}, {}}
 	inputChan := make(chan *Arrays)

--- a/generate/test_data/complex_avro_test.go
+++ b/generate/test_data/complex_avro_test.go
@@ -44,6 +44,39 @@ func TestComplex_WriteAvroCF(t *testing.T) {
 	}
 }
 
+func TestComplex_WriteAvroDeletedCF(t *testing.T) {
+	z := &Complex{} // In real usage at minimum an ID field should be populated
+
+	// compile error if for some reason z does not implement generate.AvroCFDeleter
+	var _ generate.AvroCFDeleter = z
+
+	// write to a CF file
+	now := time.Now()
+	buf := &bytes.Buffer{}
+	err := z.WriteAvroDeletedCF(buf, now)
+	if err != nil {
+		t.Fatalf("Unexpected error writing to a CF file: %v", err)
+	}
+
+	ocfReader, err := complex.NewComplexReader(buf)
+	if err != nil {
+		t.Fatalf("Error creating OCF file reader: %v\n", err)
+	}
+
+	read, err := ocfReader.Read()
+	if err != nil {
+		t.Fatalf("Failed reading from OCF file reader: %v\n", err)
+	}
+
+	if got, want := read.AvroWriteTime, generate.AvroTime(now); got != want {
+		t.Errorf("Time is wrong, got %d, want %d", got, want)
+	}
+
+	if read.AvroDeleted != true {
+		t.Error("OCF reports deleted false expected true")
+	}
+}
+
 func ExampleComplexBulkAvroWrite() {
 	input := []*Complex{{}, {}, {}}
 	inputChan := make(chan *Complex)

--- a/generate/test_data/repeats_avro.go
+++ b/generate/test_data/repeats_avro.go
@@ -1,6 +1,7 @@
 package test_data
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -12,10 +13,12 @@ import (
 
 // WriteAvroCF writes an Avro Containter File to the given io.Writer using snappy compression for the data.
 // The time is used as the AvroWriteTime, if the time is the Zero value then the current time is used.
-// If z is nil then the data will be a delete as indicated by the AvroDeleted field.
 // NOTE: If the type has a field in an embedded struct with the same name as a field not in the embedded struct the
 // value will be pulled from the field not in the embedded struct.
 func (z *Repeats) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
 	if writeTime.IsZero() {
 		writeTime = time.Now()
 	}
@@ -25,6 +28,28 @@ func (z *Repeats) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
 	}
 
 	if err := avroWriter.WriteRecord(z.convertToAvro(writeTime)); err != nil {
+		return err
+	}
+
+	return avroWriter.Flush()
+}
+
+// WriteAvroDeletedCF works nearly identically to WriteAvroCF but sets the AvroDeleted metadata field to true.
+func (z *Repeats) WriteAvroDeletedCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
+	if writeTime.IsZero() {
+		writeTime = time.Now()
+	}
+	avroWriter, err := repeats.NewRepeatsWriter(writer, container.Snappy, 1)
+	if err != nil {
+		return err
+	}
+
+	converted := z.convertToAvro(writeTime)
+	converted.AvroDeleted = true
+	if err := avroWriter.WriteRecord(converted); err != nil {
 		return err
 	}
 
@@ -53,6 +78,8 @@ func (z *Repeats) convertToAvro(writeTime time.Time) *repeats.Repeats {
 // The given writeTime will be used for all data items written by this function.
 // When the returned request channel is closed this function will finalize the Container File and exit.
 // The returned error channel will be closed just before the go routine exits.
+// Note: That though a nil item will be written as delete it will also be written without an ID or other identifying
+// field and so this is of limited value. In general deletes should be done using WriteAvroDeletedCF.
 func RepeatsBulkAvroWriter(writer io.Writer, writeTime time.Time, request <-chan *Repeats) <-chan error {
 	if writeTime.IsZero() {
 		writeTime = time.Now()

--- a/generate/test_data/repeats_avro_test.go
+++ b/generate/test_data/repeats_avro_test.go
@@ -44,6 +44,39 @@ func TestRepeats_WriteAvroCF(t *testing.T) {
 	}
 }
 
+func TestRepeats_WriteAvroDeletedCF(t *testing.T) {
+	z := &Repeats{} // In real usage at minimum an ID field should be populated
+
+	// compile error if for some reason z does not implement generate.AvroCFDeleter
+	var _ generate.AvroCFDeleter = z
+
+	// write to a CF file
+	now := time.Now()
+	buf := &bytes.Buffer{}
+	err := z.WriteAvroDeletedCF(buf, now)
+	if err != nil {
+		t.Fatalf("Unexpected error writing to a CF file: %v", err)
+	}
+
+	ocfReader, err := repeats.NewRepeatsReader(buf)
+	if err != nil {
+		t.Fatalf("Error creating OCF file reader: %v\n", err)
+	}
+
+	read, err := ocfReader.Read()
+	if err != nil {
+		t.Fatalf("Failed reading from OCF file reader: %v\n", err)
+	}
+
+	if got, want := read.AvroWriteTime, generate.AvroTime(now); got != want {
+		t.Errorf("Time is wrong, got %d, want %d", got, want)
+	}
+
+	if read.AvroDeleted != true {
+		t.Error("OCF reports deleted false expected true")
+	}
+}
+
 func ExampleRepeatsBulkAvroWrite() {
 	input := []*Repeats{{}, {}, {}}
 	inputChan := make(chan *Repeats)

--- a/generate/test_data/simple_avro.go
+++ b/generate/test_data/simple_avro.go
@@ -1,6 +1,7 @@
 package test_data
 
 import (
+	"errors"
 	"io"
 	"time"
 
@@ -12,10 +13,12 @@ import (
 
 // WriteAvroCF writes an Avro Containter File to the given io.Writer using snappy compression for the data.
 // The time is used as the AvroWriteTime, if the time is the Zero value then the current time is used.
-// If z is nil then the data will be a delete as indicated by the AvroDeleted field.
 // NOTE: If the type has a field in an embedded struct with the same name as a field not in the embedded struct the
 // value will be pulled from the field not in the embedded struct.
 func (z *Simple) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
 	if writeTime.IsZero() {
 		writeTime = time.Now()
 	}
@@ -25,6 +28,28 @@ func (z *Simple) WriteAvroCF(writer io.Writer, writeTime time.Time) error {
 	}
 
 	if err := avroWriter.WriteRecord(z.convertToAvro(writeTime)); err != nil {
+		return err
+	}
+
+	return avroWriter.Flush()
+}
+
+// WriteAvroDeletedCF works nearly identically to WriteAvroCF but sets the AvroDeleted metadata field to true.
+func (z *Simple) WriteAvroDeletedCF(writer io.Writer, writeTime time.Time) error {
+	if z == nil {
+		return errors.New("unable to write a nil pointer")
+	}
+	if writeTime.IsZero() {
+		writeTime = time.Now()
+	}
+	avroWriter, err := simple.NewSimpleWriter(writer, container.Snappy, 1)
+	if err != nil {
+		return err
+	}
+
+	converted := z.convertToAvro(writeTime)
+	converted.AvroDeleted = true
+	if err := avroWriter.WriteRecord(converted); err != nil {
 		return err
 	}
 
@@ -52,6 +77,8 @@ func (z *Simple) convertToAvro(writeTime time.Time) *simple.Simple {
 // The given writeTime will be used for all data items written by this function.
 // When the returned request channel is closed this function will finalize the Container File and exit.
 // The returned error channel will be closed just before the go routine exits.
+// Note: That though a nil item will be written as delete it will also be written without an ID or other identifying
+// field and so this is of limited value. In general deletes should be done using WriteAvroDeletedCF.
 func SimpleBulkAvroWriter(writer io.Writer, writeTime time.Time, request <-chan *Simple) <-chan error {
 	if writeTime.IsZero() {
 		writeTime = time.Now()

--- a/generate/test_data/simple_avro_test.go
+++ b/generate/test_data/simple_avro_test.go
@@ -44,6 +44,39 @@ func TestSimple_WriteAvroCF(t *testing.T) {
 	}
 }
 
+func TestSimple_WriteAvroDeletedCF(t *testing.T) {
+	z := &Simple{} // In real usage at minimum an ID field should be populated
+
+	// compile error if for some reason z does not implement generate.AvroCFDeleter
+	var _ generate.AvroCFDeleter = z
+
+	// write to a CF file
+	now := time.Now()
+	buf := &bytes.Buffer{}
+	err := z.WriteAvroDeletedCF(buf, now)
+	if err != nil {
+		t.Fatalf("Unexpected error writing to a CF file: %v", err)
+	}
+
+	ocfReader, err := simple.NewSimpleReader(buf)
+	if err != nil {
+		t.Fatalf("Error creating OCF file reader: %v\n", err)
+	}
+
+	read, err := ocfReader.Read()
+	if err != nil {
+		t.Fatalf("Failed reading from OCF file reader: %v\n", err)
+	}
+
+	if got, want := read.AvroWriteTime, generate.AvroTime(now); got != want {
+		t.Errorf("Time is wrong, got %d, want %d", got, want)
+	}
+
+	if read.AvroDeleted != true {
+		t.Error("OCF reports deleted false expected true")
+	}
+}
+
 func ExampleSimpleBulkAvroWrite() {
 	input := []*Simple{{}, {}, {}}
 	inputChan := make(chan *Simple)


### PR DESCRIPTION
The new function allows populating the object with some data, such as
an ID before writing the Avro file.