### PR TITLE
Properly handle xml transform when the data has repeated values for a scalar

### DIFF
--- a/transform.adoc
+++ b/transform.adoc
@@ -47,6 +47,7 @@ The transform object has the following properties:
 
 - Objects can optionally have an xmlPath transform. If an object does have this transform all fields inside of it will be relative to that selection with it now acting as the root node, meaning nodes above the selected object transform node will be inaccessible inside that object. If a transform is placed on an object and it is not found all children fields inside the object will be skipped.
 
+- In the event of multiple values for a scalar item in an XML document strings are space concatenated, the first item is used for other scalar types.
 
 === Operations
 

--- a/transform/test_data/xml/repeatedScalarNode.json
+++ b/transform/test_data/xml/repeatedScalarNode.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "description": "Test a scalar value which has multiple repeated items matching it in the xml",
+  "additionalProperties": false,
+  "properties": {
+    "body": {
+      "type": "string",
+      "transform": {
+        "ows": {
+          "from": [
+            {
+              "xmlPath": "/onl:story/onl:content/onl:paragraphs/onl:paragraph/onl:body"
+            }
+          ]
+        }
+      }
+    },
+    "approved": {
+      "type": "boolean",
+      "transform": {
+        "ows": {
+          "from": [
+            {
+              "xmlPath": "/onl:story/onl:approved"
+            }
+          ]
+        }
+      }
+    },
+    "average": {
+      "type": "number",
+      "transform": {
+        "ows": {
+          "from": [
+            {
+              "xmlPath": "/onl:story/onl:average"
+            }
+          ]
+        }
+      }
+    },
+    "count": {
+      "type": "integer",
+      "transform": {
+        "ows": {
+          "from": [
+            {
+              "xmlPath": "/onl:story/onl:count"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/transform/test_data/xml/repeatedScalarNode.out.json
+++ b/transform/test_data/xml/repeatedScalarNode.out.json
@@ -1,0 +1,1 @@
+{"approved":true,"average":1.1,"body": "Operation: next regular meeting on Tuesday, Jan. 5, at 7 p.m. More Body text","count":2}

--- a/transform/test_data/xml/repeatedScalarNode.xml
+++ b/transform/test_data/xml/repeatedScalarNode.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<onl:story xmlns:onl="http://test">
+    <onl:approved>true</onl:approved>
+    <onl:approved>false</onl:approved>
+    <onl:average>1.1</onl:average>
+    <onl:average>2.2</onl:average>
+    <onl:count>2</onl:count>
+    <onl:count>4</onl:count>
+    <onl:content>
+        <onl:paragraphs>
+            <onl:paragraph html="0">
+                <onl:body><![CDATA[Operation: next regular meeting on Tuesday, Jan. 5, at 7 p.m.]]></onl:body>
+            </onl:paragraph>
+            <onl:paragraph html="0">
+                <onl:body>More Body text</onl:body>
+            </onl:paragraph>
+        </onl:paragraphs>
+    </onl:content>
+</onl:story>

--- a/transform/transform.go
+++ b/transform/transform.go
@@ -105,7 +105,6 @@ func (ti *transformInstruction) xmlTransform(in interface{}, fieldType string, m
 	if xmlNode == nil {
 		return nil, nil
 	}
-	rawValue := xmlNode
 
 	var (
 		value interface{}
@@ -122,13 +121,23 @@ func (ti *transformInstruction) xmlTransform(in interface{}, fieldType string, m
 	if numElementsWithChild == 0 && numElementsWithoutChild == 1 {
 		value, err = convert(xmlNode[0].InnerText(), fieldType)
 	} else {
-		value = xmlNode
+		switch fieldType {
+		case "array", "object":
+			value = xmlNode
+		case "string":
+			values := make([]string, len(xmlNode))
+			for i, node := range xmlNode {
+				values[i] = node.InnerText()
+			}
+			value = strings.Join(values, " ")
+		default:
+			value, err = convert(xmlNode[0].InnerText(), fieldType)
+			if err != nil {
+				value = xmlNode
+			}
+		}
 	}
 
-	if err != nil {
-		// In some cases the conversion is helpful but in others like before a max operation it isn't
-		value = rawValue
-	}
 	if value == nil {
 		return nil, nil
 	}

--- a/transform/transformer_test.go
+++ b/transform/transformer_test.go
@@ -3,11 +3,12 @@ package transform
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/GannettDigital/jstransform/jsonschema"
 	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/GannettDigital/jstransform/jsonschema"
 )
 
 // used for the Transformer test and benchmark
@@ -565,6 +566,13 @@ func TestNewXMLTransformer(t *testing.T) {
 			schemaFilePath:      "./test_data/xml/xmlRefsTest/baseballBoxscores.json",
 			xmlFilePath:         "./test_data/xml/xmlRefsTest/boxscoreBaseball.xml",
 			wantFilePath:        "./test_data/xml/xmlRefsTest/boxscores.out.json",
+		},
+		{
+			description:         "transform where the xml has more than 1 value for a scalar item",
+			transformIdentifier: "ows",
+			schemaFilePath:      "./test_data/xml/repeatedScalarNode.json",
+			xmlFilePath:         "./test_data/xml/repeatedScalarNode.xml",
+			wantFilePath:        "./test_data/xml/repeatedScalarNode.out.json",
 		},
 	}
 


### PR DESCRIPTION
Strings are concatenated with a space in between. For other types the first value is used.