### PR TITLE
APIS-7217 - Persist GraphQL type renaming into its sub-objects.

### DIFF
--- a/generate/graphql_test.go
+++ b/generate/graphql_test.go
@@ -258,7 +258,6 @@ func TestGraphQLExtractedField_Write(t *testing.T) {
 func TestGraphQLGeneratedStruct(t *testing.T) {
 	tests := []struct {
 		description            string
-		embeds                 []string
 		schemaPath             string
 		packageName            string
 		oneOfType              string
@@ -279,7 +278,6 @@ func TestGraphQLGeneratedStruct(t *testing.T) {
 		},
 		{
 			description:    "Complex schema - no nest",
-			embeds:         []string{"Simple"},
 			schemaPath:     "graphql_test_data/test_schema.json",
 			packageName:    "nonest",
 			noNestedStruct: true,
@@ -322,7 +320,6 @@ func TestGraphQLGeneratedStruct(t *testing.T) {
 		},
 		{
 			description:  "Complex schema",
-			embeds:       []string{"Simple"},
 			schemaPath:   "graphql_test_data/test_schema.json",
 			packageName:  "test_data",
 			oneOfType:    "complex",
@@ -356,7 +353,7 @@ func TestGraphQLGeneratedStruct(t *testing.T) {
 			FieldNameMap:           test.renameFieldMap,
 			NoNestedStructs:        test.noNestedStruct,
 		}
-		g, err := newGeneratedGraphQLFile(schema.Instance, test.oneOfType, test.packageName, test.embeds, bArgs)
+		g, err := newGeneratedGraphQLFile(schema.Instance, test.oneOfType, test.packageName, false, bArgs)
 		if err != nil {
 			t.Fatalf("Test %q - failed: %v", test.description, err)
 		}

--- a/generate/graphql_test_data/complex.graphqls
+++ b/generate/graphql_test_data/complex.graphqls
@@ -1,6 +1,6 @@
 
-interface complex @goModel(model: ".Complex") {
-Simple  caption: String!
+interface Complex @goModel(model: ".Complex") {
+  caption: String!
 
   credit: String!
 

--- a/generate/graphql_test_data/needs_field_rename.graphqls.out
+++ b/generate/graphql_test_data/needs_field_rename.graphqls.out
@@ -1,5 +1,5 @@
 
-type rename @goModel(model: ".Rename") {
+type Rename @goModel(model: ".Rename") {
   caption: String!
 
   credit: String!

--- a/generate/graphql_test_data/nested.graphqls
+++ b/generate/graphql_test_data/nested.graphqls
@@ -1,5 +1,5 @@
 
-type nested @goModel(model: ".Nested") {
+type Nested @goModel(model: ".Nested") {
   "Information related to the International Fact-Checking Network (IFCN) program"
   factCheckClaims(
     "A List Filter expression such as '{Field: \"position\", Operation: \"<=\", Argument: {Value: 10}}'"

--- a/generate/graphql_test_data/nonest/complex.graphqls
+++ b/generate/graphql_test_data/nonest/complex.graphqls
@@ -1,6 +1,6 @@
 
-interface complex @goModel(model: ".Complex") {
-Simple  caption: String!
+interface Complex @goModel(model: ".Complex") {
+  caption: String!
 
   credit: String!
 

--- a/generate/graphql_test_data/nonest/nested.graphqls
+++ b/generate/graphql_test_data/nonest/nested.graphqls
@@ -1,5 +1,5 @@
 
-type nested @goModel(model: ".Nested") {
+type Nested @goModel(model: ".Nested") {
   "Information related to the International Fact-Checking Network (IFCN) program"
   factCheckClaims(
     "A List Filter expression such as '{Field: \"position\", Operation: \"<=\", Argument: {Value: 10}}'"

--- a/generate/graphql_test_data/nonest/simple.graphqls
+++ b/generate/graphql_test_data/nonest/simple.graphqls
@@ -1,5 +1,5 @@
 
-interface simple @goModel(model: ".Simple") {
+interface Simple @goModel(model: ".Simple") {
   contributors(
     "A List Filter expression such as '{Field: \"position\", Operation: \"<=\", Argument: {Value: 10}}'"
     filter: ListFilter

--- a/generate/graphql_test_data/simple.graphqls
+++ b/generate/graphql_test_data/simple.graphqls
@@ -1,5 +1,5 @@
 
-interface simple @goModel(model: ".Simple") {
+interface Simple @goModel(model: ".Simple") {
   contributors(
     "A List Filter expression such as '{Field: \"position\", Operation: \"<=\", Argument: {Value: 10}}'"
     filter: ListFilter

--- a/generate/graphql_test_data/simple.graphqls.out-rename-fields
+++ b/generate/graphql_test_data/simple.graphqls.out-rename-fields
@@ -1,5 +1,5 @@
 
-interface simple @goModel(model: ".Simple") {
+interface Simple @goModel(model: ".Simple") {
   contributors(
     "A List Filter expression such as '{Field: \"position\", Operation: \"<=\", Argument: {Value: 10}}'"
     filter: ListFilter


### PR DESCRIPTION
This means that if a "base.json" JSON schema is renamed to "Example", meaning the top-level GraphQL type is "Example", then a sub-object named "Dog" would not be named "BaseDog" but rather follow the top-level naming and be called "ExampleDog".